### PR TITLE
feat(api): Implement API endpoints for user and category management

### DIFF
--- a/app/Http/Controllers/Api/V1/UserCategoriaController.php
+++ b/app/Http/Controllers/Api/V1/UserCategoriaController.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Api\V1\BaseApiController;
+use App\Http\Requests\Api\AttachCategoriaRequest;
+use App\Http\Requests\Api\SyncCategoriasRequest;
+use App\Http\Resources\V1\CategoriaResource;
+use App\Models\Categoria;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class UserCategoriaController extends BaseApiController
+{
+    /**
+     * Retorna todas as categorias associadas ao usuário.
+     *
+     * @param User $user
+     * @return JsonResponse
+     */
+    public function index(User $user): JsonResponse
+    {
+        try {
+            $categorias = $user->categorias()->withPivot('created_at')->get();
+
+            return $this->successResponse([
+                'data' => CategoriaResource::collection($categorias)
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Erro ao listar categorias do usuário', [
+                'user_id' => $user->id,
+                'error' => $e->getMessage()
+            ]);
+
+            return $this->internalServerErrorResponse('Erro ao listar categorias do usuário.');
+        }
+    }
+
+    /**
+     * Associa uma categoria ao usuário (operação idempotente).
+     *
+     * @param AttachCategoriaRequest $request
+     * @param User $user
+     * @return JsonResponse
+     */
+    public function attach(AttachCategoriaRequest $request, User $user): JsonResponse
+    {
+        try {
+            $categoriaId = $request->validated()['categoria_id'];
+            $categoria = Categoria::findOrFail($categoriaId);
+
+            // Verifica se a associação já existe (idempotência)
+            $existing = $user->categorias()->where('categoria_id', $categoriaId)->first();
+
+            if ($existing) {
+                // Associação já existe - retorna 200 OK em vez de 201
+                return $this->successResponse([
+                    'user_id' => $user->id,
+                    'categoria_id' => $categoria->id,
+                    'categoria_nome' => $categoria->nome,
+                    'created_at' => $existing->pivot->created_at,
+                ], 'Categoria já estava associada ao usuário.');
+            }
+
+            // Cria nova associação
+            $user->categorias()->attach($categoriaId);
+
+            // Busca a associação recém-criada para obter o timestamp
+            $newAssociation = $user->categorias()->where('categoria_id', $categoriaId)->first();
+
+            Log::info('Categoria associada ao usuário', [
+                'user_id' => $user->id,
+                'categoria_id' => $categoriaId,
+                'created_by' => auth()->id()
+            ]);
+
+            return $this->createdResponse([
+                'user_id' => $user->id,
+                'categoria_id' => $categoria->id,
+                'categoria_nome' => $categoria->nome,
+                'created_at' => $newAssociation->pivot->created_at,
+            ], 'Categoria associada com sucesso.');
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return $this->notFoundErrorResponse('Categoria');
+        } catch (\Exception $e) {
+            Log::error('Erro ao associar categoria ao usuário', [
+                'user_id' => $user->id,
+                'categoria_id' => $request->input('categoria_id'),
+                'error' => $e->getMessage()
+            ]);
+
+            return $this->internalServerErrorResponse('Erro ao associar categoria ao usuário.');
+        }
+    }
+
+    /**
+     * Remove a associação entre usuário e categoria.
+     *
+     * @param User $user
+     * @param Categoria $categoria
+     * @return JsonResponse
+     */
+    public function detach(User $user, Categoria $categoria): JsonResponse
+    {
+        try {
+            // Verifica se a associação existe
+            $exists = $user->categorias()->where('categoria_id', $categoria->id)->exists();
+
+            if (!$exists) {
+                return $this->notFoundErrorResponse('Associação', 'Associação não encontrada.');
+            }
+
+            // Remove a associação
+            $user->categorias()->detach($categoria->id);
+
+            Log::info('Categoria removida do usuário', [
+                'user_id' => $user->id,
+                'categoria_id' => $categoria->id,
+                'removed_by' => auth()->id()
+            ]);
+
+            return $this->deletedResponse([], 'Categoria removida com sucesso.');
+        } catch (\Exception $e) {
+            Log::error('Erro ao remover categoria do usuário', [
+                'user_id' => $user->id,
+                'categoria_id' => $categoria->id,
+                'error' => $e->getMessage()
+            ]);
+
+            return $this->internalServerErrorResponse('Erro ao remover categoria do usuário.');
+        }
+    }
+
+    /**
+     * Sincroniza as categorias do usuário (operação bulk).
+     * Remove associações não listadas, adiciona novas, mantém existentes.
+     *
+     * @param SyncCategoriasRequest $request
+     * @param User $user
+     * @return JsonResponse
+     */
+    public function sync(SyncCategoriasRequest $request, User $user): JsonResponse
+    {
+        try {
+            $categoriaIds = $request->validated()['categoria_ids'];
+
+            DB::beginTransaction();
+
+            // Sync retorna arrays com IDs attached, detached e updated
+            $syncResult = $user->categorias()->sync($categoriaIds);
+
+            DB::commit();
+
+            Log::info('Categorias sincronizadas para usuário', [
+                'user_id' => $user->id,
+                'attached' => $syncResult['attached'],
+                'detached' => $syncResult['detached'],
+                'updated' => $syncResult['updated'],
+                'synced_by' => auth()->id()
+            ]);
+
+            return $this->successResponse([
+                'attached' => $syncResult['attached'],
+                'detached' => $syncResult['detached'],
+                'updated' => $syncResult['updated'],
+            ], 'Categorias sincronizadas com sucesso.');
+        } catch (\Exception $e) {
+            DB::rollBack();
+
+            Log::error('Erro ao sincronizar categorias do usuário', [
+                'user_id' => $user->id,
+                'categoria_ids' => $request->input('categoria_ids'),
+                'error' => $e->getMessage()
+            ]);
+
+            return $this->internalServerErrorResponse('Erro ao sincronizar categorias do usuário.');
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Api\V1\BaseApiController;
+use App\Http\Requests\Api\StoreUserRequest;
+use App\Http\Resources\V1\UserResource;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+
+class UserController extends BaseApiController
+{
+    /**
+     * Busca usuário por codpes ou lista usuários.
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        try {
+            // Se codpes foi fornecido, busca por número USP
+            if ($request->has('codpes')) {
+                $codpes = $request->input('codpes');
+
+                // Valida que codpes é um inteiro
+                if (!is_numeric($codpes)) {
+                    return $this->validationErrorResponse(
+                        ['codpes' => ['O número USP (codpes) deve ser um número inteiro.']],
+                        'Parâmetro inválido.'
+                    );
+                }
+
+                $user = User::where('codpes', $codpes)->first();
+
+                if (!$user) {
+                    return $this->notFoundErrorResponse('Usuário', 'Usuário não encontrado.');
+                }
+
+                // Eager load categorias
+                $user->load('categorias');
+
+                Log::info('Usuário buscado por codpes via API', [
+                    'codpes' => $codpes,
+                    'user_id' => $user->id,
+                    'searched_by' => auth()->id()
+                ]);
+
+                return $this->successResponse(new UserResource($user));
+            }
+
+            // Se não há filtro, retorna erro (podemos implementar listagem depois se necessário)
+            return $this->validationErrorResponse(
+                ['codpes' => ['O parâmetro codpes é obrigatório para busca de usuários.']],
+                'Parâmetro obrigatório ausente.'
+            );
+        } catch (\Exception $e) {
+            Log::error('Erro ao buscar usuário', [
+                'codpes' => $request->input('codpes'),
+                'error' => $e->getMessage()
+            ]);
+
+            return $this->internalServerErrorResponse('Erro ao buscar usuário.');
+        }
+    }
+
+    /**
+     * Cria um novo usuário no sistema.
+     *
+     * @param StoreUserRequest $request
+     * @return JsonResponse
+     */
+    public function store(StoreUserRequest $request): JsonResponse
+    {
+        try {
+            $validated = $request->validated();
+
+            // Se a senha não foi fornecida, gera uma senha aleatória
+            // (usuários podem redefinir via Senhaunica ou outro mecanismo)
+            if (!isset($validated['password'])) {
+                $validated['password'] = Hash::make(bin2hex(random_bytes(16)));
+            } else {
+                $validated['password'] = Hash::make($validated['password']);
+            }
+
+            $user = User::create($validated);
+
+            Log::info('Usuário criado via API', [
+                'user_id' => $user->id,
+                'codpes' => $user->codpes,
+                'created_by' => auth()->id()
+            ]);
+
+            return $this->createdResponse(
+                new UserResource($user),
+                'Usuário criado com sucesso.'
+            );
+        } catch (\Illuminate\Database\QueryException $e) {
+            // Trata erros de duplicação que possam ter escapado da validação
+            if ($e->getCode() === '23000') {
+                return $this->validationErrorResponse(
+                    ['codpes' => ['Este número USP ou e-mail já está cadastrado.']],
+                    'Erro de duplicação de dados.'
+                );
+            }
+
+            Log::error('Erro ao criar usuário', [
+                'error' => $e->getMessage(),
+                'data' => $request->except('password')
+            ]);
+
+            return $this->databaseErrorResponse('Erro ao criar usuário.');
+        } catch (\Exception $e) {
+            Log::error('Erro ao criar usuário', [
+                'error' => $e->getMessage(),
+                'data' => $request->except('password')
+            ]);
+
+            return $this->internalServerErrorResponse('Erro ao criar usuário.');
+        }
+    }
+
+    /**
+     * Retorna informações detalhadas do usuário.
+     *
+     * @param User $user
+     * @return JsonResponse
+     */
+    public function show(User $user): JsonResponse
+    {
+        try {
+            // Eager load categorias para incluir no response
+            $user->load('categorias');
+
+            return $this->successResponse(new UserResource($user));
+        } catch (\Exception $e) {
+            Log::error('Erro ao buscar usuário', [
+                'user_id' => $user->id,
+                'error' => $e->getMessage()
+            ]);
+
+            return $this->internalServerErrorResponse('Erro ao buscar informações do usuário.');
+        }
+    }
+}

--- a/app/Http/Requests/Api/AttachCategoriaRequest.php
+++ b/app/Http/Requests/Api/AttachCategoriaRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttachCategoriaRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // API users with valid token can attach categories
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'categoria_id' => 'required|integer|exists:categorias,id',
+        ];
+    }
+
+    /**
+     * Get the validation messages for the defined validation rules.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'categoria_id.required' => 'O ID da categoria é obrigatório.',
+            'categoria_id.integer' => 'O ID da categoria deve ser um número inteiro.',
+            'categoria_id.exists' => 'A categoria selecionada não existe no sistema.',
+        ];
+    }
+
+    /**
+     * Get custom attributes for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'categoria_id' => 'ID da categoria',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/StoreUserRequest.php
+++ b/app/Http/Requests/Api/StoreUserRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // API users with valid token can create users
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'codpes' => 'required|integer|unique:users,codpes',
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|max:255|unique:users,email',
+            'password' => 'nullable|string|min:8',
+        ];
+    }
+
+    /**
+     * Get the validation messages for the defined validation rules.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'codpes.required' => 'O número USP (codpes) é obrigatório.',
+            'codpes.integer' => 'O número USP (codpes) deve ser um número inteiro.',
+            'codpes.unique' => 'Este número USP (codpes) já está cadastrado no sistema.',
+            'name.required' => 'O nome é obrigatório.',
+            'name.string' => 'O nome deve ser um texto válido.',
+            'name.max' => 'O nome não pode exceder 255 caracteres.',
+            'email.required' => 'O e-mail é obrigatório.',
+            'email.email' => 'O e-mail deve ser um endereço válido.',
+            'email.max' => 'O e-mail não pode exceder 255 caracteres.',
+            'email.unique' => 'Este e-mail já está cadastrado no sistema.',
+            'password.string' => 'A senha deve ser um texto válido.',
+            'password.min' => 'A senha deve ter no mínimo 8 caracteres.',
+        ];
+    }
+
+    /**
+     * Get custom attributes for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'codpes' => 'número USP',
+            'name' => 'nome',
+            'email' => 'e-mail',
+            'password' => 'senha',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/SyncCategoriasRequest.php
+++ b/app/Http/Requests/Api/SyncCategoriasRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SyncCategoriasRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // API users with valid token can sync categories
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'categoria_ids' => 'required|array|min:1',
+            'categoria_ids.*' => 'required|integer|exists:categorias,id',
+        ];
+    }
+
+    /**
+     * Get the validation messages for the defined validation rules.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'categoria_ids.required' => 'É necessário informar pelo menos uma categoria.',
+            'categoria_ids.array' => 'Os IDs de categorias devem ser fornecidos como um array.',
+            'categoria_ids.min' => 'É necessário informar pelo menos uma categoria.',
+            'categoria_ids.*.required' => 'Cada ID de categoria é obrigatório.',
+            'categoria_ids.*.integer' => 'Cada ID de categoria deve ser um número inteiro.',
+            'categoria_ids.*.exists' => 'Uma ou mais categorias selecionadas não existem no sistema.',
+        ];
+    }
+
+    /**
+     * Get custom attributes for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'categoria_ids' => 'IDs de categorias',
+            'categoria_ids.*' => 'ID de categoria',
+        ];
+    }
+}

--- a/app/Http/Resources/V1/UserResource.php
+++ b/app/Http/Resources/V1/UserResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'codpes' => $this->codpes,
+            'name' => $this->name,
+            'email' => $this->email,
+            'categorias' => CategoriaResource::collection($this->whenLoaded('categorias')),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/docs/endpoints_api.md
+++ b/docs/endpoints_api.md
@@ -8,6 +8,8 @@
   - [Consulta Otimizada de Reservas](#consulta-otimizada-de-reservas)
   - [Gestão de Reservas](#gestão-de-reservas)
   - [Status de Reservas](#status-de-reservas)
+  - [👥 Gestão de Usuários](#-gestão-de-usuários)
+  - [🔑 Gestão de Permissões Usuário-Categoria](#-gestão-de-permissões-usuário-categoria)
 - [🔄 Reservas Recorrentes](#-reservas-recorrentes-ac6)
 - [🔍 Códigos de Erro Detalhados](#-códigos-de-erro-detalhados)
 
@@ -800,6 +802,416 @@ As reservas no sistema podem ter os seguintes status:
 - **`rejeitada`**: Reserva negada pelos responsáveis da sala
 
 **Importante:** Apenas reservas com status `pendente` podem ser aprovadas ou rejeitadas através dos endpoints acima.
+
+---
+
+### 👥 Gestão de Usuários
+
+#### Buscar Usuário por Número USP
+
+**GET** `/api/v1/users?codpes={codpes}` *(protegido)*
+
+Busca um usuário pelo número USP (codpes). Útil para verificar se um usuário já existe no sistema antes de criá-lo.
+
+**Parâmetros de Query:**
+- `codpes` (integer, obrigatório): Número USP do usuário
+
+**Autorização:**
+- Requer token de autenticação válido
+- Aplica throttle do grupo `api` (100 req/min)
+
+**Exemplo de Request:**
+```http
+GET /api/v1/users?codpes=2803642
+Authorization: Bearer 1|A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0
+```
+
+**Exemplo de Response (200 OK) - Usuário encontrado:**
+```json
+{
+    "data": {
+        "id": 123,
+        "codpes": 2803642,
+        "name": "João da Silva",
+        "email": "joao.silva@usp.br",
+        "categorias": [
+            {
+                "id": 1,
+                "nome": "Padrão",
+                "vinculo_cadastrado": "Pessoas da unidade",
+                "setores_cadastrados": ["Assistência Técnica"],
+                "salas": []
+            }
+        ],
+        "created_at": "2025-10-01T10:30:00.000000Z",
+        "updated_at": "2025-10-01T10:30:00.000000Z"
+    }
+}
+```
+
+**Exemplo de Response (404 Not Found) - Usuário não existe:**
+```json
+{
+    "error": "Not Found",
+    "message": "Usuário não encontrado.",
+    "details": {
+        "type": "resource_not_found",
+        "code": "not_found"
+    }
+}
+```
+
+**Casos de Uso:**
+1. **Migração de Dados**: Verificar se usuário já existe antes de importar
+2. **Integração de Sistemas**: Buscar ID do usuário a partir do número USP
+3. **Validação**: Confirmar existência de usuário antes de associar permissões
+
+**Workflow Recomendado (Migração):**
+```
+1. GET /api/v1/users?codpes={codpes}
+   - Se 200 OK → usuário existe, usar o ID retornado
+   - Se 404 → usuário não existe, criar com POST /users
+2. PUT /api/v1/users/{id}/categorias
+   - Sincronizar categorias/permissões
+```
+
+**Errors:**
+- `401`: Token de autenticação inválido
+- `404`: Usuário não encontrado
+- `422`: Parâmetro codpes ausente ou não numérico
+- `500`: Erro interno do servidor
+
+---
+
+#### Criação de Usuários
+
+**POST** `/api/v1/users` *(protegido)*
+
+Cria um novo usuário no sistema. Útil para integração com sistemas externos e migração de dados.
+
+**Parâmetros:**
+- `codpes` (integer, obrigatório): Número USP do usuário
+- `name` (string, obrigatório): Nome completo do usuário (máx. 255 caracteres)
+- `email` (string, obrigatório): E-mail válido e único
+- `password` (string, opcional): Senha do usuário (mín. 8 caracteres). Se omitida, uma senha aleatória será gerada.
+
+**Autorização:**
+- Requer token de autenticação válido
+- Aplica throttle do grupo `api` (100 req/min)
+
+**Exemplo de Request:**
+```http
+POST /api/v1/users
+Authorization: Bearer 1|A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0
+Content-Type: application/json
+
+{
+    "codpes": 1234567,
+    "name": "João da Silva",
+    "email": "joao.silva@usp.br",
+    "password": "senha_segura_123"
+}
+```
+
+**Exemplo de Response (201 Created):**
+```json
+{
+    "data": {
+        "id": 123,
+        "codpes": 1234567,
+        "name": "João da Silva",
+        "email": "joao.silva@usp.br",
+        "categorias": [],
+        "created_at": "2025-10-01T10:30:00.000000Z",
+        "updated_at": "2025-10-01T10:30:00.000000Z"
+    },
+    "message": "Usuário criado com sucesso."
+}
+```
+
+**Errors:**
+- `401`: Token de autenticação inválido
+- `422`: Validação falhou (codpes ou email duplicado, campos obrigatórios ausentes)
+- `500`: Erro interno do servidor
+
+---
+
+#### Consulta de Usuário
+
+**GET** `/api/v1/users/{user}` *(protegido)*
+
+Retorna informações detalhadas de um usuário, incluindo suas categorias associadas.
+
+**Parâmetros:**
+- `{user}` (obrigatório): ID do usuário
+
+**Autorização:**
+- Requer token de autenticação válido
+
+**Exemplo de Request:**
+```http
+GET /api/v1/users/123
+Authorization: Bearer 1|TOKEN
+```
+
+**Exemplo de Response (200 OK):**
+```json
+{
+    "data": {
+        "id": 123,
+        "codpes": 1234567,
+        "name": "João da Silva",
+        "email": "joao.silva@usp.br",
+        "categorias": [
+            {
+                "id": 1,
+                "nome": "Padrão",
+                "vinculo_cadastrado": "Pessoas da unidade",
+                "setores_cadastrados": ["Assistência Técnica"],
+                "salas": []
+            },
+            {
+                "id": 2,
+                "nome": "Auditório",
+                "vinculo_cadastrado": "Pessoas da USP",
+                "setores_cadastrados": [],
+                "salas": []
+            }
+        ],
+        "created_at": "2025-10-01T10:30:00.000000Z",
+        "updated_at": "2025-10-01T10:30:00.000000Z"
+    }
+}
+```
+
+**Errors:**
+- `401`: Token de autenticação inválido
+- `404`: Usuário não encontrado
+- `500`: Erro interno do servidor
+
+---
+
+### 🔑 Gestão de Permissões Usuário-Categoria
+
+#### Listar Categorias do Usuário
+
+**GET** `/api/v1/users/{user}/categorias` *(protegido)*
+
+Retorna todas as categorias associadas a um usuário específico.
+
+**Parâmetros:**
+- `{user}` (obrigatório): ID do usuário
+
+**Autorização:**
+- Requer token de autenticação válido
+
+**Exemplo de Request:**
+```http
+GET /api/v1/users/123/categorias
+Authorization: Bearer 1|TOKEN
+```
+
+**Exemplo de Response (200 OK):**
+```json
+{
+    "data": {
+        "data": [
+            {
+                "id": 1,
+                "nome": "Padrão",
+                "vinculo_cadastrado": "Pessoas da unidade",
+                "setores_cadastrados": ["Assistência Técnica"],
+                "salas": []
+            },
+            {
+                "id": 2,
+                "nome": "Auditório",
+                "vinculo_cadastrado": "Pessoas da USP",
+                "setores_cadastrados": [],
+                "salas": []
+            }
+        ]
+    }
+}
+```
+
+**Errors:**
+- `401`: Token de autenticação inválido
+- `404`: Usuário não encontrado
+- `500`: Erro interno do servidor
+
+---
+
+#### Associar Categoria ao Usuário
+
+**POST** `/api/v1/users/{user}/categorias` *(protegido)*
+
+Associa uma categoria a um usuário. Esta operação é **idempotente**: se a associação já existe, retorna status 200 ao invés de 201.
+
+**Parâmetros:**
+- `{user}` (obrigatório): ID do usuário
+- `categoria_id` (integer, obrigatório): ID da categoria a ser associada
+
+**Autorização:**
+- Requer token de autenticação válido
+
+**Exemplo de Request:**
+```http
+POST /api/v1/users/123/categorias
+Authorization: Bearer 1|TOKEN
+Content-Type: application/json
+
+{
+    "categoria_id": 1
+}
+```
+
+**Exemplo de Response (201 Created) - Nova associação:**
+```json
+{
+    "data": {
+        "user_id": 123,
+        "categoria_id": 1,
+        "categoria_nome": "Padrão",
+        "created_at": "2025-10-01T10:30:00.000000Z"
+    },
+    "message": "Categoria associada com sucesso."
+}
+```
+
+**Exemplo de Response (200 OK) - Associação já existia (idempotência):**
+```json
+{
+    "data": {
+        "user_id": 123,
+        "categoria_id": 1,
+        "categoria_nome": "Padrão",
+        "created_at": "2025-09-15T08:20:00.000000Z"
+    },
+    "message": "Categoria já estava associada ao usuário."
+}
+```
+
+**Errors:**
+- `401`: Token de autenticação inválido
+- `404`: Usuário não encontrado
+- `422`: Categoria não existe ou categoria_id ausente
+- `500`: Erro interno do servidor
+
+---
+
+#### Remover Categoria do Usuário
+
+**DELETE** `/api/v1/users/{user}/categorias/{categoria}` *(protegido)*
+
+Remove a associação entre um usuário e uma categoria.
+
+**Parâmetros:**
+- `{user}` (obrigatório): ID do usuário
+- `{categoria}` (obrigatório): ID da categoria
+
+**Autorização:**
+- Requer token de autenticação válido
+
+**Exemplo de Request:**
+```http
+DELETE /api/v1/users/123/categorias/1
+Authorization: Bearer 1|TOKEN
+```
+
+**Exemplo de Response (200 OK):**
+```json
+{
+    "message": "Categoria removida com sucesso."
+}
+```
+
+**Errors:**
+- `401`: Token de autenticação inválido
+- `404`: Usuário, categoria ou associação não encontrada
+- `500`: Erro interno do servidor
+
+---
+
+#### Sincronizar Categorias do Usuário (Operação Bulk)
+
+**PUT** `/api/v1/users/{user}/categorias` *(protegido)*
+
+Sincroniza as categorias do usuário de forma atômica. Remove associações não listadas, adiciona novas e mantém existentes.
+
+**Parâmetros:**
+- `{user}` (obrigatório): ID do usuário
+- `categoria_ids` (array, obrigatório): Array de IDs de categorias (mínimo 1 item)
+
+**Autorização:**
+- Requer token de autenticação válido
+
+**Comportamento:**
+- Remove todas as associações que **não** estão no array
+- Adiciona novas associações para IDs que não existiam
+- Mantém associações que já existem
+- Operação é executada dentro de uma transação (tudo ou nada)
+
+**Exemplo de Request:**
+```http
+PUT /api/v1/users/123/categorias
+Authorization: Bearer 1|TOKEN
+Content-Type: application/json
+
+{
+    "categoria_ids": [1, 3]
+}
+```
+
+**Exemplo de Response (200 OK):**
+```json
+{
+    "data": {
+        "attached": [3],
+        "detached": {
+            "1": 2
+        },
+        "updated": []
+    },
+    "message": "Categorias sincronizadas com sucesso.",
+    "meta": {
+        "success": true
+    }
+}
+```
+
+**Descrição dos Campos de Response:**
+- `attached`: Array de IDs de categorias que foram adicionadas
+- `detached`: Object/Array com IDs de categorias que foram removidas
+- `updated`: Array de IDs de categorias que foram atualizadas (geralmente vazio)
+
+**Casos de Uso:**
+1. **Migração de Permissões**: Sincronizar permissões de sistemas legados (ex: Urano → Salas)
+2. **Gestão de Perfis**: Aplicar conjunto de permissões baseado em role (ADM, OPR, USR)
+3. **Atualização em Massa**: Atualizar permissões de múltiplos usuários programaticamente
+
+**Exemplo - Aplicar permissões de Administrador (todas as categorias):**
+```json
+{
+    "categoria_ids": [1, 2, 3]
+}
+```
+
+**Exemplo - Aplicar permissões de Usuário Padrão (apenas categoria básica):**
+```json
+{
+    "categoria_ids": [3]
+}
+```
+
+**Errors:**
+- `401`: Token de autenticação inválido
+- `404`: Usuário não encontrado
+- `422`: categoria_ids ausente, vazio ou contém IDs inválidos
+- `500`: Erro interno do servidor ou falha na transação
+
+**Rate Limiting:**
+Este endpoint utiliza o throttle `api`, oferecendo 100 requisições por minuto para operações autenticadas.
 
 ---
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,8 @@
 use App\Http\Controllers\Api\V1\CategoriaController;
 use App\Http\Controllers\Api\V1\FinalidadeController;
 use App\Http\Controllers\Api\V1\TokenController;
+use App\Http\Controllers\Api\V1\UserCategoriaController;
+use App\Http\Controllers\Api\V1\UserController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V1\ReservaController;
@@ -74,11 +76,25 @@ Route::prefix('v1')->group(function(){
     Route::middleware(['auth:sanctum', 'throttle:bulk'])->group(function() {
         // Bulk creation of reservations
         Route::post('reservas/bulk', [ReservaController::class, 'bulkStore']);
-        
+
         // Bulk update of reservations
         Route::put('reservas/bulk', [ReservaController::class, 'bulkUpdate']);
-        
+
         // Bulk delete of reservations
         Route::delete('reservas/bulk', [ReservaController::class, 'bulkDestroy']);
+    });
+
+    // Endpoints para gerenciamento de usuários e permissões
+    Route::middleware(['auth:sanctum', 'throttle:api'])->group(function() {
+        // CRUD de Usuários
+        Route::get('users', [UserController::class, 'index']);
+        Route::post('users', [UserController::class, 'store']);
+        Route::get('users/{user}', [UserController::class, 'show']);
+
+        // Gerenciamento de Categorias por Usuário
+        Route::get('users/{user}/categorias', [UserCategoriaController::class, 'index']);
+        Route::post('users/{user}/categorias', [UserCategoriaController::class, 'attach']);
+        Route::put('users/{user}/categorias', [UserCategoriaController::class, 'sync']);
+        Route::delete('users/{user}/categorias/{categoria}', [UserCategoriaController::class, 'detach']);
     });
 });

--- a/tests/Feature/Api/UserApiTest.php
+++ b/tests/Feature/Api/UserApiTest.php
@@ -1,0 +1,465 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UserApiTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Executa as migrações
+        $this->artisan('migrate');
+    }
+
+    /** @test */
+    public function it_can_find_user_by_codpes()
+    {
+        $authenticatedUser = User::factory()->create();
+        $targetUser = User::factory()->create([
+            'codpes' => 7654321,
+            'name' => 'Maria Santos',
+            'email' => 'maria.santos@usp.br'
+        ]);
+
+        Sanctum::actingAs($authenticatedUser);
+
+        $response = $this->getJson('/api/v1/users?codpes=7654321');
+
+        $response->assertStatus(200)
+                ->assertJsonStructure([
+                    'data' => [
+                        'id',
+                        'codpes',
+                        'name',
+                        'email',
+                        'categorias',
+                        'created_at',
+                        'updated_at'
+                    ]
+                ])
+                ->assertJsonPath('data.id', $targetUser->id)
+                ->assertJsonPath('data.codpes', 7654321)
+                ->assertJsonPath('data.name', 'Maria Santos')
+                ->assertJsonPath('data.email', 'maria.santos@usp.br');
+    }
+
+    /** @test */
+    public function it_returns_404_when_user_not_found_by_codpes()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $response = $this->getJson('/api/v1/users?codpes=9999999');
+
+        $response->assertStatus(404)
+                ->assertJson([
+                    'error' => 'Not Found',
+                    'message' => 'Usuário não encontrado.'
+                ]);
+    }
+
+    /** @test */
+    public function it_rejects_non_numeric_codpes()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $response = $this->getJson('/api/v1/users?codpes=abc123');
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'codpes'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_requires_codpes_parameter_for_user_search()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $response = $this->getJson('/api/v1/users');
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'codpes'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_includes_categorias_when_finding_user_by_codpes()
+    {
+        $authenticatedUser = User::factory()->create();
+        $targetUser = User::factory()->create(['codpes' => 1122334]);
+        $categoria = \App\Models\Categoria::factory()->create(['nome' => 'Auditório']);
+
+        // Associa categoria ao usuário
+        $targetUser->categorias()->attach($categoria->id);
+
+        Sanctum::actingAs($authenticatedUser);
+
+        $response = $this->getJson('/api/v1/users?codpes=1122334');
+
+        $response->assertStatus(200)
+                ->assertJsonStructure([
+                    'data' => [
+                        'id',
+                        'codpes',
+                        'name',
+                        'email',
+                        'categorias' => [
+                            '*' => [
+                                'id',
+                                'nome'
+                            ]
+                        ]
+                    ]
+                ])
+                ->assertJsonCount(1, 'data.categorias');
+    }
+
+    /** @test */
+    public function it_can_create_user_successfully()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $userData = [
+            'codpes' => 1234567,
+            'name' => 'João da Silva',
+            'email' => 'joao.silva@usp.br',
+            'password' => 'senha12345'
+        ];
+
+        $response = $this->postJson('/api/v1/users', $userData);
+
+        $response->assertStatus(201)
+                ->assertJson([
+                    'message' => 'Usuário criado com sucesso.',
+                ])
+                ->assertJsonStructure([
+                    'data' => [
+                        'id',
+                        'codpes',
+                        'name',
+                        'email',
+                        'created_at',
+                        'updated_at'
+                    ]
+                ])
+                ->assertJsonPath('data.codpes', 1234567)
+                ->assertJsonPath('data.name', 'João da Silva')
+                ->assertJsonPath('data.email', 'joao.silva@usp.br');
+
+        // Verifica se o usuário foi criado no banco
+        $this->assertDatabaseHas('users', [
+            'codpes' => 1234567,
+            'name' => 'João da Silva',
+            'email' => 'joao.silva@usp.br'
+        ]);
+
+        // Verifica que a senha foi hasheada
+        $user = User::where('codpes', 1234567)->first();
+        $this->assertTrue(Hash::check('senha12345', $user->password));
+    }
+
+    /** @test */
+    public function it_can_create_user_without_password()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $userData = [
+            'codpes' => 7654321,
+            'name' => 'Maria Santos',
+            'email' => 'maria.santos@usp.br'
+        ];
+
+        $response = $this->postJson('/api/v1/users', $userData);
+
+        $response->assertStatus(201)
+                ->assertJson([
+                    'message' => 'Usuário criado com sucesso.',
+                ])
+                ->assertJsonPath('data.codpes', 7654321)
+                ->assertJsonPath('data.name', 'Maria Santos');
+
+        // Verifica que o usuário foi criado com senha gerada automaticamente
+        $user = User::where('codpes', 7654321)->first();
+        $this->assertNotNull($user->password);
+        $this->assertNotEmpty($user->password);
+    }
+
+    /** @test */
+    public function it_can_show_user_details()
+    {
+        $authenticatedUser = User::factory()->create();
+        $targetUser = User::factory()->create([
+            'codpes' => 9876543,
+            'name' => 'Pedro Oliveira',
+            'email' => 'pedro.oliveira@usp.br'
+        ]);
+
+        Sanctum::actingAs($authenticatedUser);
+
+        $response = $this->getJson("/api/v1/users/{$targetUser->id}");
+
+        $response->assertStatus(200)
+                ->assertJsonStructure([
+                    'data' => [
+                        'id',
+                        'codpes',
+                        'name',
+                        'email',
+                        'categorias',
+                        'created_at',
+                        'updated_at'
+                    ]
+                ])
+                ->assertJsonPath('data.id', $targetUser->id)
+                ->assertJsonPath('data.codpes', 9876543)
+                ->assertJsonPath('data.name', 'Pedro Oliveira')
+                ->assertJsonPath('data.email', 'pedro.oliveira@usp.br');
+    }
+
+    /** @test */
+    public function it_rejects_duplicate_codpes()
+    {
+        $authenticatedUser = User::factory()->create();
+        $existingUser = User::factory()->create(['codpes' => 1111111]);
+
+        Sanctum::actingAs($authenticatedUser);
+
+        $userData = [
+            'codpes' => 1111111,
+            'name' => 'Outro Usuário',
+            'email' => 'outro@usp.br'
+        ];
+
+        $response = $this->postJson('/api/v1/users', $userData);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'codpes'
+                        ]
+                    ]
+                ])
+                ->assertJsonPath('details.validation_errors.codpes.0', 'Este número USP (codpes) já está cadastrado no sistema.');
+    }
+
+    /** @test */
+    public function it_rejects_duplicate_email()
+    {
+        $authenticatedUser = User::factory()->create();
+        $existingUser = User::factory()->create(['email' => 'existente@usp.br']);
+
+        Sanctum::actingAs($authenticatedUser);
+
+        $userData = [
+            'codpes' => 2222222,
+            'name' => 'Novo Usuário',
+            'email' => 'existente@usp.br'
+        ];
+
+        $response = $this->postJson('/api/v1/users', $userData);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'email'
+                        ]
+                    ]
+                ])
+                ->assertJsonPath('details.validation_errors.email.0', 'Este e-mail já está cadastrado no sistema.');
+    }
+
+    /** @test */
+    public function it_rejects_invalid_email_format()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $userData = [
+            'codpes' => 3333333,
+            'name' => 'Usuário Teste',
+            'email' => 'email-invalido'
+        ];
+
+        $response = $this->postJson('/api/v1/users', $userData);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'email'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_requires_all_mandatory_fields()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $response = $this->postJson('/api/v1/users', []);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'codpes',
+                            'name',
+                            'email'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_rejects_name_exceeding_max_length()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $userData = [
+            'codpes' => 4444444,
+            'name' => str_repeat('a', 256), // 256 caracteres (excede o limite de 255)
+            'email' => 'teste@usp.br'
+        ];
+
+        $response = $this->postJson('/api/v1/users', $userData);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'name'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_rejects_password_shorter_than_8_characters()
+    {
+        $authenticatedUser = User::factory()->create();
+        Sanctum::actingAs($authenticatedUser);
+
+        $userData = [
+            'codpes' => 5555555,
+            'name' => 'Usuário Teste',
+            'email' => 'teste@usp.br',
+            'password' => '1234567' // 7 caracteres
+        ];
+
+        $response = $this->postJson('/api/v1/users', $userData);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'password'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_rejects_unauthenticated_requests_to_create_user()
+    {
+        $userData = [
+            'codpes' => 6666666,
+            'name' => 'Usuário Não Autenticado',
+            'email' => 'naoauth@usp.br'
+        ];
+
+        $response = $this->postJson('/api/v1/users', $userData);
+
+        $response->assertStatus(401);
+    }
+
+    /** @test */
+    public function it_rejects_unauthenticated_requests_to_show_user()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->getJson("/api/v1/users/{$user->id}");
+
+        $response->assertStatus(401);
+    }
+
+    // Note: Testing non-existent users (404) requires proper exception handling
+    // Laravel's route model binding will throw ModelNotFoundException
+    // which is automatically converted to 404 by Laravel's exception handler
+
+    /** @test */
+    public function it_includes_categorias_when_showing_user()
+    {
+        $authenticatedUser = User::factory()->create();
+        $targetUser = User::factory()->create();
+        $categoria = \App\Models\Categoria::factory()->create(['nome' => 'Padrão']);
+
+        // Associa categoria ao usuário
+        $targetUser->categorias()->attach($categoria->id);
+
+        Sanctum::actingAs($authenticatedUser);
+
+        $response = $this->getJson("/api/v1/users/{$targetUser->id}");
+
+        $response->assertStatus(200)
+                ->assertJsonStructure([
+                    'data' => [
+                        'id',
+                        'codpes',
+                        'name',
+                        'email',
+                        'categorias' => [
+                            '*' => [
+                                'id',
+                                'nome'
+                            ]
+                        ]
+                    ]
+                ])
+                ->assertJsonCount(1, 'data.categorias');
+    }
+}

--- a/tests/Feature/Api/UserCategoriaTest.php
+++ b/tests/Feature/Api/UserCategoriaTest.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Categoria;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UserCategoriaTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Executa as migrações
+        $this->artisan('migrate');
+    }
+
+    /** @test */
+    public function it_can_attach_category_to_user_successfully()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+        $categoria = Categoria::factory()->create(['nome' => 'Padrão']);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson("/api/v1/users/{$targetUser->id}/categorias", [
+            'categoria_id' => $categoria->id
+        ]);
+
+        $response->assertStatus(201)
+                ->assertJson([
+                    'message' => 'Categoria associada com sucesso.',
+                    'data' => [
+                        'user_id' => $targetUser->id,
+                        'categoria_id' => $categoria->id,
+                        'categoria_nome' => 'Padrão',
+                    ]
+                ])
+                ->assertJsonStructure([
+                    'data' => [
+                        'user_id',
+                        'categoria_id',
+                        'categoria_nome',
+                        'created_at'
+                    ]
+                ]);
+
+        // Verifica se a associação foi criada no banco
+        $this->assertDatabaseHas('categoria_user', [
+            'user_id' => $targetUser->id,
+            'categoria_id' => $categoria->id
+        ]);
+    }
+
+    /** @test */
+    public function it_returns_200_when_attaching_existing_category_idempotency()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+        $categoria = Categoria::factory()->create(['nome' => 'Auditório']);
+
+        // Associa a categoria primeiro
+        $targetUser->categorias()->attach($categoria->id);
+
+        Sanctum::actingAs($user);
+
+        // Tenta associar novamente
+        $response = $this->postJson("/api/v1/users/{$targetUser->id}/categorias", [
+            'categoria_id' => $categoria->id
+        ]);
+
+        $response->assertStatus(200)
+                ->assertJson([
+                    'message' => 'Categoria já estava associada ao usuário.',
+                    'data' => [
+                        'user_id' => $targetUser->id,
+                        'categoria_id' => $categoria->id,
+                    ]
+                ]);
+
+        // Verifica que não há duplicatas
+        $count = $targetUser->categorias()->where('categoria_id', $categoria->id)->count();
+        $this->assertEquals(1, $count);
+    }
+
+    /** @test */
+    public function it_can_detach_category_from_user_successfully()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+        $categoria = Categoria::factory()->create(['nome' => 'Sala Nobre']);
+
+        // Associa a categoria primeiro
+        $targetUser->categorias()->attach($categoria->id);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->deleteJson("/api/v1/users/{$targetUser->id}/categorias/{$categoria->id}");
+
+        $response->assertStatus(200)
+                ->assertJson([
+                    'message' => 'Categoria removida com sucesso.'
+                ]);
+
+        // Verifica que a associação foi removida
+        $this->assertDatabaseMissing('categoria_user', [
+            'user_id' => $targetUser->id,
+            'categoria_id' => $categoria->id
+        ]);
+    }
+
+    /** @test */
+    public function it_returns_404_when_detaching_non_existent_association()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+        $categoria = Categoria::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->deleteJson("/api/v1/users/{$targetUser->id}/categorias/{$categoria->id}");
+
+        $response->assertStatus(404)
+                ->assertJson([
+                    'error' => 'Not Found',
+                    'message' => 'Associação não encontrada.'
+                ]);
+    }
+
+    /** @test */
+    public function it_can_list_user_categories()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+        $categoria1 = Categoria::factory()->create(['nome' => 'Padrão']);
+        $categoria2 = Categoria::factory()->create(['nome' => 'Auditório']);
+        $categoria3 = Categoria::factory()->create(['nome' => 'Sala Nobre']);
+
+        // Associa algumas categorias
+        $targetUser->categorias()->attach([$categoria1->id, $categoria2->id]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson("/api/v1/users/{$targetUser->id}/categorias");
+
+        $response->assertStatus(200)
+                ->assertJsonStructure([
+                    'data' => [
+                        'data' => [
+                            '*' => [
+                                'id',
+                                'nome',
+                            ]
+                        ]
+                    ]
+                ])
+                ->assertJsonCount(2, 'data.data');
+    }
+
+    /** @test */
+    public function it_can_sync_categories_for_user()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+        $categoria1 = Categoria::factory()->create(['nome' => 'Padrão']);
+        $categoria2 = Categoria::factory()->create(['nome' => 'Auditório']);
+        $categoria3 = Categoria::factory()->create(['nome' => 'Sala Nobre']);
+
+        // Associa categorias iniciais
+        $targetUser->categorias()->attach([$categoria1->id, $categoria2->id]);
+
+        Sanctum::actingAs($user);
+
+        // Sincroniza para manter categoria1, remover categoria2, adicionar categoria3
+        $response = $this->putJson("/api/v1/users/{$targetUser->id}/categorias", [
+            'categoria_ids' => [$categoria1->id, $categoria3->id]
+        ]);
+
+        $response->assertStatus(200)
+                ->assertJson([
+                    'message' => 'Categorias sincronizadas com sucesso.',
+                ])
+                ->assertJsonPath('data.attached.0', $categoria3->id)
+                ->assertJsonPath('data.updated', []);
+
+        // Verifica o estado final
+        $this->assertDatabaseHas('categoria_user', [
+            'user_id' => $targetUser->id,
+            'categoria_id' => $categoria1->id
+        ]);
+        $this->assertDatabaseHas('categoria_user', [
+            'user_id' => $targetUser->id,
+            'categoria_id' => $categoria3->id
+        ]);
+        $this->assertDatabaseMissing('categoria_user', [
+            'user_id' => $targetUser->id,
+            'categoria_id' => $categoria2->id
+        ]);
+    }
+
+    /** @test */
+    public function it_rejects_attach_with_non_existent_category()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson("/api/v1/users/{$targetUser->id}/categorias", [
+            'categoria_id' => 99999
+        ]);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'categoria_id'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_rejects_attach_without_categoria_id()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson("/api/v1/users/{$targetUser->id}/categorias", []);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'categoria_id'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_rejects_sync_with_invalid_categoria_ids()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->putJson("/api/v1/users/{$targetUser->id}/categorias", [
+            'categoria_ids' => [99999, 88888]
+        ]);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors'
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_rejects_sync_with_empty_array()
+    {
+        $user = User::factory()->create();
+        $targetUser = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->putJson("/api/v1/users/{$targetUser->id}/categorias", [
+            'categoria_ids' => []
+        ]);
+
+        $response->assertStatus(422)
+                ->assertJsonStructure([
+                    'error',
+                    'message',
+                    'details' => [
+                        'validation_errors' => [
+                            'categoria_ids'
+                        ]
+                    ]
+                ]);
+    }
+
+    /** @test */
+    public function it_rejects_unauthenticated_requests_to_attach()
+    {
+        $targetUser = User::factory()->create();
+        $categoria = Categoria::factory()->create();
+
+        $response = $this->postJson("/api/v1/users/{$targetUser->id}/categorias", [
+            'categoria_id' => $categoria->id
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    /** @test */
+    public function it_rejects_unauthenticated_requests_to_detach()
+    {
+        $targetUser = User::factory()->create();
+        $categoria = Categoria::factory()->create();
+
+        $response = $this->deleteJson("/api/v1/users/{$targetUser->id}/categorias/{$categoria->id}");
+
+        $response->assertStatus(401);
+    }
+
+    /** @test */
+    public function it_rejects_unauthenticated_requests_to_list()
+    {
+        $targetUser = User::factory()->create();
+
+        $response = $this->getJson("/api/v1/users/{$targetUser->id}/categorias");
+
+        $response->assertStatus(401);
+    }
+
+    /** @test */
+    public function it_rejects_unauthenticated_requests_to_sync()
+    {
+        $targetUser = User::factory()->create();
+        $categoria = Categoria::factory()->create();
+
+        $response = $this->putJson("/api/v1/users/{$targetUser->id}/categorias", [
+            'categoria_ids' => [$categoria->id]
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    // Note: Testing non-existent users (404) requires proper exception handling
+    // Laravel's route model binding will throw ModelNotFoundException
+    // which is automatically converted to 404 by Laravel's exception handler
+}


### PR DESCRIPTION
## Summary
This PR implements comprehensive API endpoints for managing user-category permissions, as detailed in Issue #10. It provides full CRUD-like functionality for associating, detaching, listing, and syncing categories for users, along with an endpoint for creating new users. These endpoints are crucial for the automated migration of permissions from the Urano system.

## Changes Made
- **New Controller**: \`app/Http/Controllers/Api/V1/UserCategoriaController.php\`
  - \`POST /api/v1/users/{user}/categorias\`: Attach a category to a user (idempotent).
  - \`DELETE /api/v1/users/{user}/categorias/{categoria}\`: Detach a category from a user.
  - \`GET /api/v1/users/{user}/categorias\`: List all categories associated with a user.
  - \`PUT /api/v1/users/{user}/categorias\`: Sync categories for a user (bulk operation).
- **New Controller**: \`app/Http/Controllers/Api/V1/UserController.php\`
  - \`POST /api/v1/users\`: Create a new user.
  - \`GET /api/v1/users/{user}\`: Show a specific user.
- **Updated Resource**: \`app/Http/Resources/V1/UserResource.php\` to include \`categorias\` when loaded.
- **New Requests**: \`app/Http/Requests/Api/AttachCategoriaRequest.php\` and \`app/Http/Requests/Api/SyncCategoriasRequest.php\` for validation.
- **Updated Routes**: \`routes/api.php\` to include the new API endpoints.
- **New Tests**: \`tests/Feature/Api/UserCategoriaTest.php\` and \`tests/Feature/Api/UserTest.php\` for comprehensive API testing.

## Related Issues
Closes #10